### PR TITLE
Restart gearmand on config changes too

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -19,6 +19,7 @@
   template: src=mod_gearman2_worker.conf.j2 dest=/etc/mod_gearman2/mod_gearman2_worker.conf
   notify:
     - restart mod-gearman2-worker
+    - restart gearmand
 
 - name: Create nagios checks directory
   file: path=/usr/local/nagios/ state=directory recurse=yes force=yes


### PR DESCRIPTION
With only a mod_gearman2 worker restart for removing a host group,
the queue for the removed host group will still be in gearman_top2 but with 0
workers.